### PR TITLE
Update opx-config-route

### DIFF
--- a/bin/opx-config-route
+++ b/bin/opx-config-route
@@ -57,6 +57,11 @@ def build_ip_obj(ip_addr, prefix_len, version, vrf, ifname):
         cps_utils.add_attr_type('base-ip/ipv4/address/ip',"ipv4")
         cps_obj=cps_utils.CPSObject('base-ip/ipv4/address',data=data_dict)
         return cps_obj
+    elif version == "ipv6":
+        data_dict={'base-ip/ipv6/vrf-name':vrf,'base-ip/ipv6/address/prefix-length':prefix_len,'base-ip/ipv6/name':ifname, 'base-ip/ipv6/address/ip':ip_addr}
+        cps_utils.add_attr_type('base-ip/ipv6/address/ip',"ipv6")
+        cps_obj=cps_utils.CPSObject('base-ip/ipv6/address',data=data_dict)
+        return cps_obj
 
 def check_vrf_exists(given_vrf):
     obj=cps_object.CPSObject('ni/network-instances')
@@ -136,9 +141,6 @@ if __name__ == "__main__":
         version, prefix_len, ip_addr = ip.version, ip.prefixlen, ip.ip
         print "version, prefix_len, ip_addr",version, prefix_len, ip_addr
         version = 'ipv' + str(version)
-    if version == "ipv6":
-        print "currently ipv6 configuration not supported by this command"
-        sys.exit()
     #Check VRF exists
     if not check_vrf_exists(vrf):
         sys.exit()

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([opx-tools],[2.0.1+opx2],[ops-dev@lists.openswitch.net])
+AC_INIT([opx-tools],[2.0.1+opx3],[ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_MACRO_DIRS([m4])
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+opx-tools (2.0.1+opx3) unstable; urgency=medium
+
+  * Update: Add ipv6 address configuration support in opx-config-route
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Wed, 13 March 2019 10:32:35 -0700
+
 opx-tools (2.0.1+opx2) unstable; urgency=medium
 
   * Bugfix: slave ports not coming up when LAG is created through opx-config-lag


### PR DESCRIPTION
Add ipv6 address configuration support in opx-config-route.

**Testing output:**

**root@196ef989d8cb:/# opx-config-route create --ip_addr '2001:0db8::1/64' --ifname 'e101-001-0'**
```
version, prefix_len, ip_addr 6 64 2001:db8::1
Configuring ip address to an interface
Success
```
**root@196ef989d8cb:/# ifconfig e101-001-0**
```
e101-001-0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet6 2001:db8::1  prefixlen 64  scopeid 0x0<global>
        ether 00:0c:29:a2:7e:88  txqueuelen 1000  (Ethernet)
        RX packets 129  bytes 9118 (8.9 KiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 29785  bytes 4413370 (4.2 MiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```
**root@196ef989d8cb:/# opx-config-route create --vrf_name default --dst 5::5/64 --nh_addr '2001:db8::2'**
```
Success
Total time for adding 1 routes = 0.004194 seconds

root@196ef989d8cb:/# ip -6 route show
5::/64 via 2001:db8::2 dev e101-001-0 metric 1024  pref medium
2001:db8::/64 dev e101-001-0 proto kernel metric 256  pref medium
unreachable fe80::/64 dev lo proto kernel metric 256  error -101 pref medium
fe80::/64 dev eth0 proto kernel metric 256  pref medium
```
**root@196ef989d8cb:/# opx-show-route**
```
VRF: default
Dest        | Next hop     | Interface   | Next hop VRF
-------------------------------------------------------
0.0.0.0     | 10.11.58.254 | eth0       | default
10.11.58.0  | 0.0.0.0      | eth0       | default
5::         | 2001:db8::2  | e101-001-0 | default
2001:db8::  | ::           | e101-001-0 | default
2001:db8::1 | ::           | e101-001-0 | default
fe80::      | None         | None        | None
```

**root@196ef989d8cb:/# opx-config-route delete --vrf_name default --dst 5::5/64**
```
Success
Total time for deleting 1 routes = 0.003397 seconds

root@196ef989d8cb:/# ip -6 route show
2001:db8::/64 dev e101-001-0 proto kernel metric 256  pref medium
unreachable fe80::/64 dev lo proto kernel metric 256  error -101 pref medium
fe80::/64 dev eth0 proto kernel metric 256  pref medium
```
root@196ef989d8cb:/# opx-config-route delete --ip_addr '2001:0db8::1/64' --ifname 'e101-001-0'
```
version, prefix_len, ip_addr 6 64 2001:db8::1
Deleting ip address from the given interface: 2001:db8::1
Success
```
root@196ef989d8cb:/# ifconfig e101-001-0
```
e101-001-0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        ether 00:0c:29:a2:7e:88  txqueuelen 1000  (Ethernet)
        RX packets 129  bytes 9118 (8.9 KiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 29804  bytes 4417296 (4.2 MiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```



Signed-off-by: Tejaswi Goel <Tejaswi_Goel@Dell.com>