### PR TITLE
fix: Recognize management ports as a distinct port type

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([opx-tools],[2.0.0],[ops-dev@lists.openswitch.net])
+AC_INIT([opx-tools],[2.0.1],[ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_MACRO_DIRS([m4])
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+opx-tools (2.0.1) unstable; urgency=medium
+
+  * fix: Recognize management ports as a distinct port type
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Mon, 18 Mar 2019 16:30:00 -0800
+
 opx-tools (2.0.0) unstable; urgency=medium
 
   * Feature: OPX config/show utilities

--- a/lib/opx_config_utils.py
+++ b/lib/opx_config_utils.py
@@ -80,12 +80,14 @@ def port_name_to_type(nm):
     if n == 2:
         return 'vlan' if port_name_to_type(li[0]) in ['e', 'bond'] else None
     n = len(nm)
-    if n > 1 and nm[0] == 'e':
-        return 'e'
-    if n > 2 and nm[0:2] == 'br':
-        return 'br'
     if n > 4 and nm[0:4] == 'bond':
         return 'bond'
+    if n > 3 and nm[0:3] == 'eth':
+        return 'mgmt'
+    if n > 2 and nm[0:2] == 'br':
+        return 'br'
+    if n > 1 and nm[0] == 'e':
+        return 'e'
     return None
 
 


### PR DESCRIPTION
Recognize management ports as a distinct port type, so front-panel and
management ports will not be mixed in command-line utilities.

Signed-off-by: Howard Persh <Howard_Persh@dell.com>