### PR TITLE
Update: opx-show-route to display multiple next hops for same dst

### DIFF
--- a/bin/opx-config-route
+++ b/bin/opx-config-route
@@ -43,25 +43,21 @@ def build_route_obj(vrf, route_prefix, prefix_len, version):
         obj.add_attr("af", socket.AF_INET6)
     else:
         print "wrong ip format entered"
-
     obj.add_attr_type("route-prefix", version)
     obj.add_attr("route-prefix", str(route_prefix))
     obj.add_attr("prefix-len", int(prefix_len))
-
     return obj
-
 
 def build_ip_obj(ip_addr, prefix_len, version, vrf, ifname):
     if version == "ipv4":
         data_dict={'base-ip/ipv4/vrf-name':vrf,'base-ip/ipv4/address/prefix-length':prefix_len,'base-ip/ipv4/name':ifname, 'base-ip/ipv4/address/ip':ip_addr}
         cps_utils.add_attr_type('base-ip/ipv4/address/ip',"ipv4")
         cps_obj=cps_utils.CPSObject('base-ip/ipv4/address',data=data_dict)
-        return cps_obj
     elif version == "ipv6":
         data_dict={'base-ip/ipv6/vrf-name':vrf,'base-ip/ipv6/address/prefix-length':prefix_len,'base-ip/ipv6/name':ifname, 'base-ip/ipv6/address/ip':ip_addr}
         cps_utils.add_attr_type('base-ip/ipv6/address/ip',"ipv6")
         cps_obj=cps_utils.CPSObject('base-ip/ipv6/address',data=data_dict)
-        return cps_obj
+    return cps_obj
 
 def check_vrf_exists(given_vrf):
     obj=cps_object.CPSObject('ni/network-instances')
@@ -92,7 +88,6 @@ def add_embd_param(obj, outer_param, inner_param, val_list, type=''):
         obj.add_embed_attr(el, val)
         count = count + 1
         del el[1:]
-
 
 def nas_route_op(op, obj, ver):
     l=[]
@@ -152,7 +147,7 @@ if __name__ == "__main__":
         op = 'create'
         nas_route_op (op, obj,version)
 
-    #Delete IP address from the given interface 
+    #Delete IP address from the given interface
     if op == 'delete' and ifname and ip_addr:
         print "Deleting ip address from the given interface:",ip_addr 
         obj=build_ip_obj(str(ip.ip), prefix_len, version, vrf, ifname)
@@ -186,6 +181,7 @@ if __name__ == "__main__":
         end = time.time()
         print 'Total time for adding %d routes = %f seconds' % (int (num_of_routes),(end - start))
 
+    #Update route
     elif op == 'set'and dst_addr != '' and nh_addr != '':
         cps_obj = build_route_obj(vrf,route_prefix, prefix_len, version)
         add_embd_param(cps_obj, "nh-list", "nh-addr", nh_ip_list, version)

--- a/bin/opx-show-route
+++ b/bin/opx-show-route
@@ -33,17 +33,23 @@ def vrf_view_routes(vrf):
     obj=cps_object.CPSObject('base-route/obj/entry', data={'base-route/obj/vrf-name':vrf})
     cps.get([obj.get()],l)
     for i in l:
-        dst_address=get_ip_addr_str(str(i['data']['base-route/obj/entry/route-prefix']))
+        data=i['data']
+        nh_list=[]
+        nh_list_key='base-route/obj/entry/nh-list'
+        dst_address=get_ip_addr_str(str(data['base-route/obj/entry/route-prefix']))
+        prefix_len=ba_utils.from_ba(data['base-route/obj/entry/prefix-len'], 'uint8_t')
+        dst_address=dst_address+"/"+str(prefix_len)
         try:
-            nh_addr=get_ip_addr_str(str(i['data']['base-route/obj/entry/nh-list']['0']['base-route/obj/entry/nh-list/nh-addr']))
-            nh_vrf_name=(str(i['data']['base-route/obj/entry/nh-vrf-name']))
+            for key in data[nh_list_key]:
+                nh_addr=(get_ip_addr_str(str(data[nh_list_key][key]['base-route/obj/entry/nh-list/nh-addr'])))+' '
+                iface=(str(data[nh_list_key][key]['base-route/obj/entry/nh-list/ifname']))
+                nh_vrf_name=(str(data['base-route/obj/entry/nh-vrf-name']))
+                nh_list.append(nh_addr+" dev "+iface)
         except:
-            nh_addr=None; nh_vrf_name=None
-        try:
-            iface=str(i['data']['base-route/obj/entry/nh-list']['0']['base-route/obj/entry/nh-list/ifname'])
-        except:
-            iface="None"
-        result += [[dst_address,nh_addr,iface,nh_vrf_name,nh_vrf_name]]
+            nh_addr='None'; nh_vrf_name=None;iface='None'
+            nh_list.append(nh_addr+" dev "+iface)
+        for nh_str in nh_list:
+            result += [[dst_address,nh_str,nh_vrf_name]]
     return result
 
 def get_vrf_names():
@@ -70,8 +76,8 @@ def get_all_routes():
         get_vrf_routes(vrf)
 
 def get_vrf_routes(vrf):
-    result= vrf_view_routes(vrf) 
-    print_summary(["Dest","Next hop","Interface","Next hop VRF"],result,[None, None, None,None])
+    result= vrf_view_routes(vrf)
+    print_summary(["Dest","Next hop","Next hop VRF"],result,[None, None, None,None])
 
 
 if __name__ == "__main__":
@@ -80,7 +86,7 @@ if __name__ == "__main__":
     parser.add_argument("--vrf_name", help="view specific VRF routes")
     args = parser.parse_args()
     vrf=args.vrf_name
-    if vrf == None:	
+    if vrf == None:
         get_all_routes()
     else:
         get_vrf_routes(vrf)

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([opx-tools],[2.0.1+opx3],[ops-dev@lists.openswitch.net])
+AC_INIT([opx-tools],[2.0.1+opx4],[ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_MACRO_DIRS([m4])
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+opx-tools (2.0.1+opx4) unstable; urgency=medium
+
+  * Update: opx-show-route to display mulitple next hops
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Mon, 18 March 2019 16:32:35 -0700
+
 opx-tools (2.0.1+opx3) unstable; urgency=medium
 
   * Update: Add ipv6 address configuration support in opx-config-route


### PR DESCRIPTION
Test output:

```
root@OPX:~# opx-show-route

VRF: default
Dest          | Next hop                     | Next hop VRF
-----------------------------------------------------------
0.0.0.0/0     | 10.11.59.254  dev eth0      | default
10.1.1.0/24   | 0.0.0.0  dev e101-001-0     | default
10.1.1.1/32   | 0.0.0.0  dev e101-001-0     | default
10.11.59.0/24 | 0.0.0.0  dev eth0           | default
12.1.1.0/24   | 0.0.0.0  dev e101-002-0     | default
12.1.1.1/32   | 0.0.0.0  dev e101-002-0     | default
20.0.0.0/32   | 100.0.0.2  dev e101-003-0   | default
100.0.0.0/8   | 0.0.0.0  dev e101-003-0     | default
100.0.0.1/32  | 0.0.0.0  dev e101-003-0     | default
100.1.1.0/24  | 10.1.1.2  dev e101-001-0    | default
100.1.1.0/24  | 10.1.1.1  dev e101-001-0    | default
100.1.1.0/24  | 12.1.1.4  dev e101-002-0    | default
100.1.1.0/24  | 10.1.1.3  dev e101-001-0    | default
100.1.1.0/24  | 12.1.1.5  dev e101-002-0    | default
100.1.1.0/32  | 12.1.1.4  dev e101-002-0    | default
100.1.1.0/32  | 12.1.1.3  dev e101-002-0    | default
5::/64        | 2001:db8::2  dev e101-001-0 | default
2001:db8::/64 | ::  dev e101-001-0          | default
fe80::/10     | None dev None                | None
```

Signed-off-by: Tejaswi Goel <Tejaswi_Goel@Dell.com>