### PR TITLE
Bugfix: opx-show-vlan prints stacktrace  when invalid vlan id is given

### DIFF
--- a/bin/opx-config-interface
+++ b/bin/opx-config-interface
@@ -65,5 +65,4 @@ for x in attrs:
 for port in li:
     d['dell-base-if-cmn/if/interfaces/interface/if-index'] = port.idx
     if not cps_set('dell-base-if-cmn/if/interfaces/interface', 'target', d):
-        print 'Failed to set port {}'.format(port) >> sys.stderr
-    
+        print >> sys.stderr, 'Failed to set port {}'.format(port.name)

--- a/bin/opx-show-vlan
+++ b/bin/opx-show-vlan
@@ -124,7 +124,7 @@ class cli(object):
                           attr_vlan_obj,
                           {attr_intf_name:name, attr_intf_type: intf_type}
                          )   
-            if obj is not None:
+            if obj:
                 self.print_vlan(obj[0])
             else:
                 self.helper_exit("No VLAN information found")

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([opx-tools],[2.0.1+opx4],[ops-dev@lists.openswitch.net])
+AC_INIT([opx-tools],[2.0.2],[ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_MACRO_DIRS([m4])
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+opx-tools (2.0.2) unstable; urgency=medium
+
+  * Bugfix: opx-show-vlan prints stacktrace  when invalid vlan id is given
+  * Bugfix: Syntax error while printing error message in opx-config-interface
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Fri, 20 Mar 2020 04:40:00 -0700
+
 opx-tools (2.0.1+opx4) unstable; urgency=medium
 
   * Update: opx-show-route to display mulitple next hops


### PR DESCRIPTION
* Bugfix: opx-show-vlan prints stacktrace  when invalid vlan id is given (#22)

Additinally fixed syntax error in opx-config-interface while print error

